### PR TITLE
fix: handle missing when missing isotopes

### DIFF
--- a/src/properties.jl
+++ b/src/properties.jl
@@ -10,6 +10,8 @@ const synonym_properties = Dict(
     :ele => :element
 )
 
+symbol(e) = getfield(e, :symbol)
+
 """Retrieve the mass of an element isotope."""
 function mass(isotopes::Isotopes, mass_number)
     for iso in isotopes
@@ -21,7 +23,14 @@ function mass(isotopes::Isotopes, mass_number)
 end
 
 mass(element::ChemElem, mass_number) = mass(element.isotopes, mass_number)
-mass(atomic_number::Integer, mass_number) = mass(isotopes_data[atomic_number], mass_number)
+function mass(atomic_number::Integer, mass_number)
+    isotopes = isotopes_data[atomic_number]
+    if !ismissing(isotopes)
+        return mass(isotopes, mass_number)
+    else
+        return elements[atomic_number].atomic_mass
+    end
+end
 
 
 # Basic properties
@@ -74,9 +83,9 @@ mass_number(::Nothing) = nothing
 element(::AbstractParticle) = nothing
 
 function element(p::Particle)
-    @match p.symbol begin
+    @match symbol(p) begin
         :p => return elements[:H]
-        _ => return elements[p.symbol]
+        _ => return elements[symbol(p)]
     end
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -87,7 +87,7 @@ Fe-54³⁺
 function Particle(p::AbstractParticle; mass_numb=nothing, z=nothing)
     mass_number = something(mass_numb, p.mass_number)
     charge_number = something(z, p.charge_number)
-    Particle(p.symbol, charge_number, mass_number)
+    Particle(symbol(p), charge_number, mass_number)
 end
 
 """
@@ -118,7 +118,7 @@ See also: [`Particle(::AbstractString)`](@ref)
 function Particle(atomic_number::Int; mass_numb=nothing, z=0)
     element = elements[atomic_number]
     mass_number = something(mass_numb, element.mass_number)
-    Particle(element.symbol, z, mass_number)
+    Particle(symbol(element), z, mass_number)
 end
 
 """Create a proton"""


### PR DESCRIPTION
Also using function instead of dot notation