### PR TITLE
perf: optimize particle alias lookup and simplify utility functions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,15 +23,14 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.11"
-          - "1.10"
+          - "1"
           - "pre"
         os:
           - ubuntu-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -7,19 +7,7 @@ on:
     inputs:
       lookback:
         default: "3"
-permissions:
-  actions: read
-  checks: read
-  contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
+
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,12 +16,9 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
       - uses: julia-actions/cache@v2
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
+      - uses: julia-actions/julia-docdeploy@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
-        run: julia --project=docs/ docs/make.jl
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "e91dad46-2c06-47f2-8668-7ffa57fde2d9"
 authors = ["Beforerr <zzj956959688@gmail.com> and contributors"]
 version = "0.3.1"
 
+[workspace]
+projects = ["docs"]
+
 [deps]
 Match = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
 Mendeleev = "c116f080-063d-490a-9873-2b5b2cce4c34"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,5 +1,5 @@
+@time using ChargedParticles
 using Chairmarks
-using ChargedParticles
 
 p = Particle("Fe 2+")
 sp = SParticle(2, 26, 56)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,9 +34,3 @@ is_default_isotope
 ChargedParticles.is_proton
 ChargedParticles.is_electron
 ```
-
-## Constants
-
-```@docs
-ChargedParticles.PARTICLE_ALIASES
-```

--- a/src/ChargedParticles.jl
+++ b/src/ChargedParticles.jl
@@ -10,12 +10,12 @@ const elements = chem_elements
 include("./types.jl")
 include("./particle.jl")
 include("./properties.jl")
-include("./aliases.jl")
 include("./utils.jl")
 include("./typed_particles.jl")
 include("./custom_particles.jl")
 include("./special_particles.jl")
 include("./display.jl")
+include("./aliases.jl")
 
 export AbstractParticle, Particle, SParticle, CustomParticle
 export Electron, Muon, Neutron

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -7,20 +7,14 @@ const NEUTRON_ALIASES = ("neutron", "n")
 const MUON_ALIASES = ("muon", "μ", "μ-", "mu-", "mu")
 const ANTIMUON_ALIASES = ("antimuon", "μ+", "mu+")
 
-"""
-    PARTICLE_ALIASES
-
-Dictionary of common particle aliases and their corresponding (symbol, charge, mass_number) tuples.
-
-Each entry maps a string alias to a tuple of (symbol, charge, mass_number)
-"""
-PARTICLE_ALIASES = Dict(
+# Dictionary of common particle aliases and their corresponding (symbol, charge, mass_number) tuples.
+const PARTICLE_ALIASES = Dict(
     (PROTON_ALIASES .=> Ref(("H", 1, 1)))...,
-    (ELECTRON_ALIASES .=> :Electron)...,
-    (NEUTRON_ALIASES .=> :Neutron)...,
-    (POSITRON_ALIASES .=> :Positron)...,
-    (MUON_ALIASES .=> :Muon)...,
-    (ANTIMUON_ALIASES .=> :AntiMuon)...,
+    (ELECTRON_ALIASES .=> Electron)...,
+    (NEUTRON_ALIASES .=> Neutron)...,
+    (POSITRON_ALIASES .=> Positron)...,
+    (MUON_ALIASES .=> Muon)...,
+    (ANTIMUON_ALIASES .=> AntiMuon)...,
     "alpha" => ("He", 2, 4),
     "deuteron" => ("H", 1, 2),
     "D+" => ("H", 1, 2),
@@ -29,3 +23,6 @@ PARTICLE_ALIASES = Dict(
     "triton" => ("H", 1, 3),
     "T+" => ("H", 1, 3),
 )
+
+# Dictionary of common particle aliases (as Symbols) for quicker lookup.
+const PARTICLE_ALIASES_SYMBOL = Dict(Symbol(k) => v for (k, v) in PARTICLE_ALIASES)

--- a/src/particle.jl
+++ b/src/particle.jl
@@ -1,10 +1,9 @@
 """
-    particle(str::AbstractString; mass_numb=nothing, z=nothing, typed=false)
+    particle(s; mass_numb=nothing, z=nothing, typed=false)
 
-Create a particle from a string representation.
+Create a particle species from the representation `s`.
 
 # Arguments
-- `str::AbstractString`: String representation of the particle
 - `mass_numb`: Optional mass number override
 - `z`: Optional charge number override
 - `typed`: If true, creates a type-parameterized SParticle instead of a regular Particle
@@ -30,38 +29,7 @@ iron56 = particle("Fe-56")
 # output
 Fe
 ```
-"""
-function particle(str::AbstractString; mass_numb=nothing, z=nothing, typed=false)
-    # Check aliases first
-    if haskey(PARTICLE_ALIASES, str)
-        result = PARTICLE_ALIASES[str]
-        if result isa Tuple
-            symbol, charge, mass_number = result
-            symbol = Symbol(symbol)
-            return typed ? SParticle(charge, atomic_number(symbol), mass_number) : Particle(symbol, charge, mass_number)
-        else
-            return eval(result)()
-        end
-    end
 
-    # Try to parse as element with optional mass number and charge
-    result = parse_particle_string(str)
-    if !isnothing(result)
-        (symbol, parsed_charge, parsed_mass_numb) = result
-        element = elements[symbol]
-        charge = determine(parsed_charge, z; default=0)
-        mass_number = determine(parsed_mass_numb, mass_numb; default=element.mass_number)
-        return typed ? SParticle(charge, element.number, mass_number) : Particle(symbol, charge, mass_number)
-    end
-    throw(ArgumentError("Invalid particle string format: $str"))
-end
-
-"""
-    particle(sym::Symbol)
-
-Create a particle from its symbol representation.
-
-# Examples
 ```jldoctest; output = false
 # Elementary particles
 electron = particle(:e)
@@ -71,7 +39,48 @@ proton = particle(:p)
 H⁺
 ```
 """
-particle(sym::Symbol; kwargs...) = particle(string(sym); kwargs...)
+function particle end
+
+function particle(str::AbstractString; mass_numb=nothing, z=nothing, typed=false)
+    # Check aliases first
+    if haskey(PARTICLE_ALIASES, str)
+        result = PARTICLE_ALIASES[str]
+        return if result isa Tuple
+            symbol, charge, mass_number = result
+            symbol = Symbol(symbol)
+            typed ? SParticle(charge, atomic_number(symbol), mass_number) : Particle(symbol, charge, mass_number)
+        else
+            result()
+        end
+    end
+
+    # Try to parse as element with optional mass number and charge
+    result = parse_particle_string(str)
+    if !isnothing(result)
+        (symbol, parsed_charge, parsed_mass_numb) = result
+        element = elements[symbol]
+        charge = @something determine(parsed_charge, z) 0
+        mass_number = @something determine(parsed_mass_numb, mass_numb) element.mass_number
+        return typed ? SParticle(charge, element.number, mass_number) : Particle(symbol, charge, mass_number)
+    end
+    throw(ArgumentError("Invalid particle string format: $str"))
+end
+
+function particle(sym::Symbol; mass_numb=nothing, z=nothing, typed=false)
+    # Check symbol aliases first for faster lookup
+    if haskey(PARTICLE_ALIASES_SYMBOL, sym)
+        result = PARTICLE_ALIASES_SYMBOL[sym]
+        return if result isa Tuple
+            symbol, charge, mass_number = result
+            symbol = Symbol(symbol)
+            typed ? SParticle(charge, atomic_number(symbol), mass_number) : Particle(symbol, charge, mass_number)
+        else
+            result()
+        end
+    end
+    # Fall back to string-based lookup
+    particle(string(sym); mass_numb, z, typed)
+end
 
 particle(s::Symbol, charge_number::Int, mass_number::Int; typed::Bool=false) =
     typed ? SParticle(charge_number, atomic_number(s), mass_number) :
@@ -110,7 +119,7 @@ function particle(atomic_number::Int; mass_numb=nothing, z=0, typed=false)
     return typed ? SParticle(z, atomic_number, mass_number) : Particle(symbol(element), z, mass_number)
 end
 
-particle(p::AbstractParticle) = p
+particle(p::AbstractParticle; kw...) = p
 
 Particle(atomic_number::Int; mass_numb=nothing, z=0) = particle(atomic_number; mass_numb, z, typed=false)
 Particle(str::AbstractString; mass_numb=nothing, z=nothing) = particle(str; mass_numb, z, typed=false)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -83,16 +83,11 @@ false
 is_proton(p) = (p.symbol in [:H, :p]) && p.charge_number == 1 && p.mass_number == 1
 
 
-
-# Helper function to determine the value of x or y
-function determine(x, y; default=nothing)
-    @match (x, y) begin
-        ($nothing, $nothing) => default
-        (x, $nothing) => x
-        ($nothing, y) => y
-        (x, y) => x == y ? x : throw(ArgumentError("Inconsistent $x and $y"))
-    end
-end
+determine(::Nothing, y) = y
+determine(x, ::Nothing) = x
+determine(::Nothing, ::Nothing) = nothing
+# determine(x, y) = @assert x == y; x
+determine(x, y) = x == y ? x : throw(ArgumentError("Inconsistent $x and $y"))
 
 function parse_particle_string(str::AbstractString)
     pattern = r"^([A-Za-z]+)(?:-([\d]+))?(?:\s*(\d+)?([+-]))?$"


### PR DESCRIPTION
- Add PARTICLE_ALIASES_SYMBOL for faster Symbol-based lookups
- Optimize particle(::Symbol) with direct symbol alias checking
- Replace @match with simpler pattern matching in determine function
- Change alias values from Symbols to direct callable instances
